### PR TITLE
Gracefully handle missing DB env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+# Replace with your MongoDB connection string
+MONGODB_URL=mongodb+srv://user:password@cluster.mongodb.net/mydb

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # env files (can opt-in for commiting if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ pnpm dev
 bun dev
 ```
 
+### Environment variables
+
+Create a `.env` file at the project root with your MongoDB connection string:
+
+```bash
+cp .env.example .env
+```
+
+Update `MONGODB_URL` in `.env` with your database URI before running `next build` or starting the server.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -19,18 +19,24 @@ export default async function CheckoutPage() {
   let user = null;
   let cart = null;
 
-  if (session?.user?.id) {
-    const userDoc = await UserModel.findById(session.user.id).lean();
-    const cartDoc = await CartModel.findOne({ user: session.user.id }).lean();
+  if (process.env.MONGODB_URL) {
+    try {
+      if (session?.user?.id) {
+        const userDoc = await UserModel.findById(session.user.id).lean();
+        const cartDoc = await CartModel.findOne({ user: session.user.id }).lean();
 
-    if (userDoc) user = JSON.parse(JSON.stringify(userDoc));
-    if (cartDoc) cart = JSON.parse(JSON.stringify(cartDoc));
-  } else {
-    const guestId = (await cookies()).get("guestId")?.value;
-    if (!guestId) redirect("/cart");
-    cart = await CartModel.findOne({ guestId }).lean();
-    const cartDoc = await CartModel.findOne({ guestId });
-    if (cartDoc) cart = JSON.parse(JSON.stringify(cartDoc));
+        if (userDoc) user = JSON.parse(JSON.stringify(userDoc));
+        if (cartDoc) cart = JSON.parse(JSON.stringify(cartDoc));
+      } else {
+        const guestId = (await cookies()).get("guestId")?.value;
+        if (!guestId) redirect("/cart");
+        cart = await CartModel.findOne({ guestId }).lean();
+        const cartDoc = await CartModel.findOne({ guestId });
+        if (cartDoc) cart = JSON.parse(JSON.stringify(cartDoc));
+      }
+    } catch (err) {
+      console.error("Error fetching checkout data", err);
+    }
   }
 
   if (!cart || !cart.items || cart.items.length === 0) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,14 @@ import ClientHome from "@/app/clientHome";
 export default async function Home() {
   // 1. Connect to the DB and fetch poster data
   await db.connectDb();
-  const rawPosters = await PosterModel.find().sort({ createdAt: -1 }).lean();
+  let rawPosters = [] as any[];
+  if (process.env.MONGODB_URL) {
+    try {
+      rawPosters = await PosterModel.find().sort({ createdAt: -1 }).lean();
+    } catch (err) {
+      console.error("Error fetching posters from MongoDB", err);
+    }
+  }
   await db.disconnectDb();
 
   // Convert any Mongoose objects (like ObjectIds) into plain objects

--- a/src/app/posters/[slug]/page.tsx
+++ b/src/app/posters/[slug]/page.tsx
@@ -21,7 +21,14 @@ interface PageProps {
 export async function generateMetadata({ params }: PageProps) {
   const { slug } = await Promise.resolve(params);
   await db.connectDb();
-  const poster = await PosterModel.findOne({ slug }).lean();
+  let poster = null;
+  if (process.env.MONGODB_URL) {
+    try {
+      poster = await PosterModel.findOne({ slug }).lean();
+    } catch (err) {
+      console.error("Error fetching poster for metadata", err);
+    }
+  }
   if (!poster) {
     return {
       title: "Poster Not Found",
@@ -57,13 +64,20 @@ export async function generateMetadata({ params }: PageProps) {
 export default async function Page({ params }: PageProps) {
   const { slug } = await Promise.resolve(params);
   await db.connectDb();
-  const poster = await PosterModel.findOne({ slug })
-    .populate({
-      path: "category",
-      model: CategoryModel,
-      populate: { path: "parent", model: CategoryModel },
-    })
-    .lean();
+  let poster = null;
+  if (process.env.MONGODB_URL) {
+    try {
+      poster = await PosterModel.findOne({ slug })
+        .populate({
+          path: "category",
+          model: CategoryModel,
+          populate: { path: "parent", model: CategoryModel },
+        })
+        .lean();
+    } catch (err) {
+      console.error("Error fetching poster", err);
+    }
+  }
   if (!poster) {
     notFound();
   }

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -23,10 +23,20 @@ const connectDb = async (): Promise<void> => {
     await mongoose.disconnect();
   }
 
-  const db = await mongoose.connect(process.env.MONGODB_URL || "");
+  const uri = process.env.MONGODB_URL;
 
-  connection.isConnected = db.connections[0].readyState;
-  console.log("New connection established with the database.");
+  if (!uri) {
+    console.error("MONGODB_URL is not defined. Skipping database connection.");
+    return;
+  }
+
+  try {
+    const db = await mongoose.connect(uri);
+    connection.isConnected = db.connections[0].readyState;
+    console.log("New connection established with the database.");
+  } catch (error) {
+    console.error("Error connecting to MongoDB:", error);
+  }
 };
 
 const disconnectDb = async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- allow `.env.example` in version control and document copying it to `.env`
- log connection errors and skip DB connection if `MONGODB_URL` is missing
- guard DB queries in root, poster, and checkout pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687678ed846c8326bb60546af540e953